### PR TITLE
Support for MSVC

### DIFF
--- a/cc.h
+++ b/cc.h
@@ -879,7 +879,6 @@ CC_TYPEOF_XP(                                                                   
     default: _Generic( (**cntr),                                                                  \
       CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), char ):               ( char ){ 0 },               \
       CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), unsigned char ):      ( unsigned char ){ 0 },      \
-      CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), signed char ):        ( signed char ){ 0 },        \
       CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), unsigned short ):     ( unsigned short ){ 0 },     \
       CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), short ):              ( short ){ 0 },              \
       CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), unsigned int ):       ( unsigned int ){ 0 },       \
@@ -891,7 +890,10 @@ CC_TYPEOF_XP(                                                                   
       CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), cc_maybe_size_t ):    ( size_t ){ 0 },             \
       CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), char * ):             ( char * ){ 0 },             \
       CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), void * ):             ( void * ){ 0 },             \
-      default: (char){ 0 } /* Nothing. */                                                         \
+      default: _Generic( (**cntr),                                                                \
+        CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), signed char ):      ( signed char ){ 0 },        \
+        default: (char){ 0 } /* Nothing. */                                                       \
+      )                                                                                           \
     )                                                                                             \
   )                                                                                               \
 )                                                                                                 \
@@ -4189,7 +4191,6 @@ _Generic( (**cntr),                                                             
   default: _Generic( (**cntr),                                                                        \
     CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), char ):               cc_cmpr_char_select,               \
     CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), unsigned char ):      cc_cmpr_unsigned_char_select,      \
-    CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), signed char ):        cc_cmpr_signed_char_select,        \
     CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), unsigned short ):     cc_cmpr_unsigned_short_select,     \
     CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), short ):              cc_cmpr_short_select,              \
     CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), unsigned int ):       cc_cmpr_unsigned_int_select,       \
@@ -4200,7 +4201,10 @@ _Generic( (**cntr),                                                             
     CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), long long ):          cc_cmpr_long_long_select,          \
     CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), cc_maybe_size_t ):    cc_cmpr_size_t_select,             \
     CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), char * ):             cc_cmpr_c_string_select,           \
-    default: cc_cmpr_dummy_select                                                                     \
+    default: _Generic( (**cntr),                                                                      \
+      CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), signed char ):      cc_cmpr_signed_char_select,        \
+      default: cc_cmpr_dummy_select                                                                   \
+    )                                                                                                 \
   )                                                                                                   \
 )( CC_CNTR_ID( cntr ) )                                                                               \
 
@@ -4211,7 +4215,6 @@ _Generic( (**cntr),                                                             
   default: _Generic( (**cntr),                                                                 \
     CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), char ):               cc_hash_char,               \
     CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), unsigned char ):      cc_hash_unsigned_char,      \
-    CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), signed char ):        cc_hash_signed_char,        \
     CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), unsigned short ):     cc_hash_unsigned_short,     \
     CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), short ):              cc_hash_short,              \
     CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), unsigned int ):       cc_hash_unsigned_int,       \
@@ -4222,7 +4225,10 @@ _Generic( (**cntr),                                                             
     CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), long long ):          cc_hash_long_long,          \
     CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), cc_maybe_size_t ):    cc_hash_size_t,             \
     CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), char * ):             cc_hash_c_string,           \
-    default: (cc_hash_fnptr_ty)NULL                                                            \
+    default: _Generic( (**cntr),                                                               \
+      CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), signed char ):      cc_hash_signed_char,        \
+      default: (cc_hash_fnptr_ty)NULL                                                          \
+    )                                                                                          \
   )                                                                                            \
 )                                                                                              \
 
@@ -4233,7 +4239,6 @@ _Generic( (ty){ 0 },                    \
   default: _Generic( (ty){ 0 },         \
     char:               true,           \
     unsigned char:      true,           \
-    signed char:        true,           \
     unsigned short:     true,           \
     short:              true,           \
     unsigned int:       true,           \
@@ -4244,7 +4249,10 @@ _Generic( (ty){ 0 },                    \
     long long:          true,           \
     cc_maybe_size_t:    true,           \
     char *:             true,           \
-    default:            false           \
+    default: _Generic( (ty){ 0 },       \
+      signed char:      true,           \
+      default:          false           \
+    )                                   \
   )                                     \
 )                                       \
 
@@ -4255,7 +4263,6 @@ _Generic( (ty){ 0 },                    \
   default: _Generic( (ty){ 0 },         \
     char:               true,           \
     unsigned char:      true,           \
-    signed char:        true,           \
     unsigned short:     true,           \
     short:              true,           \
     unsigned int:       true,           \
@@ -4266,7 +4273,10 @@ _Generic( (ty){ 0 },                    \
     long long:          true,           \
     cc_maybe_size_t:    true,           \
     char *:             true,           \
-    default:            false           \
+    default: _Generic( (ty){ 0 },       \
+      signed char:      true,           \
+      default:          false           \
+    )                                   \
   )                                     \
 )                                       \
 
@@ -4289,8 +4299,6 @@ _Generic( (**cntr),                                                             
       ( cc_key_details_ty ){ sizeof( char ), alignof( char ) },                             \
     CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), unsigned char ) :                              \
       ( cc_key_details_ty ){ sizeof( unsigned char ), alignof( unsigned char ) },           \
-    CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), signed char ) :                                \
-      ( cc_key_details_ty ){ sizeof( signed char ), alignof( signed char ) },               \
     CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), unsigned short ) :                             \
       ( cc_key_details_ty ){ sizeof( unsigned short ), alignof( unsigned short ) },         \
     CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), short ) :                                      \
@@ -4311,7 +4319,11 @@ _Generic( (**cntr),                                                             
       ( cc_key_details_ty ){ sizeof( cc_maybe_size_t ), alignof( cc_maybe_size_t ) },       \
     CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), char * ):                                      \
       ( cc_key_details_ty ){ sizeof( char * ), alignof( char * ) },                         \
-    default: ( cc_key_details_ty ){ 0 }                                                     \
+    default: _Generic( (**cntr),                                                            \
+      CC_MAKE_BASE_FNPTR_TY( CC_EL_TY( cntr ), signed char ) :                              \
+        ( cc_key_details_ty ){ sizeof( signed char ), alignof( signed char ) },             \
+      default: ( cc_key_details_ty ){ 0 }                                                   \
+    )                                                                                       \
   )                                                                                         \
 )                                                                                           \
 

--- a/cc.h
+++ b/cc.h
@@ -737,8 +737,10 @@ CC_CAST_MAYBE_UNUSED(                                               \
 #ifdef __cplusplus
 #define CC_TYPEOF_XP( xp ) std::decay<std::remove_reference<decltype( xp )>::type>::type
 #define CC_TYPEOF_TY( ty ) std::decay<std::remove_reference<decltype( std::declval<ty>() )>::type>::type
+#elif __STDC_VERSION__ >= 202311L /* C23 */
+#define CC_TYPEOF_XP( xp ) typeof( xp )
+#define CC_TYPEOF_TY( ty ) typeof( ty )
 #else
-// TODO: Add C23 check once C23 is supported by major compilers.
 #define CC_TYPEOF_XP( xp ) __typeof__( xp )
 #define CC_TYPEOF_TY( ty ) __typeof__( ty )
 #endif

--- a/cc.h
+++ b/cc.h
@@ -674,6 +674,15 @@ template<typename ty_1, typename ty_2> ty_1 cc_maybe_unused( ty_2 xp ){ return (
 #define CC_UNLIKELY( xp ) ( xp )
 #endif
 
+// Marks a point where the program never reaches.
+#if defined( __GNUC__ )
+#define CC_UNREACHABLE() __builtin_unreachable()
+#elif defined( _MSC_VER )
+#define CC_UNREACHABLE() __assume(0)
+#else
+#define CC_UNREACHABLE() abort()
+#endif
+
 // CC_IF_THEN_CAST_TY_1_ELSE_CAST_TY_2 is the same as above, except that it selects the type to which to cast based on
 // a condition.
 // This is necessary because some API macros (e.g. cc_erase) return either a pointer-iterator or a bool depending on the
@@ -2671,7 +2680,7 @@ static inline void *cc_map_leap_backward( void *cntr, void *itr, size_t el_size,
     }
 
     if( cc_map_hdr( cntr )->metadata == &cc_map_placeholder_metadatum )
-      __builtin_unreachable();
+      CC_UNREACHABLE();
 
     uint64_t metadatum;
     memcpy( &metadatum, cc_map_hdr( cntr )->metadata + bucket - 4, sizeof( uint64_t ) );


### PR DESCRIPTION
close #9

Note that this PR introduces a new typedef cc_max_align_t and a function-like macro CC_UNREACHABLE(). Compiler specific optimizations are also added to cc_first_nonzero_uint16() and cc_last_nonzero_uint16().

By using MSVC 19.39 or later, you can compile with either option of /std:c11, /std:c17 or /std:clatest for C. In the case of C++, the /Zc:preprocessor option must be specified.