### PR TITLE
fixes linker issue

### DIFF
--- a/cc.h
+++ b/cc.h
@@ -4082,7 +4082,7 @@ static inline void *cc_omap_bounded_first_or_last(
 // Niemann's implementation of this function assumes that if the starting node is a sentinel, its parent pointer has
 // been temporarily set to point to the appropriate parent.
 // Since we never write to the sentinel, we instead pass the initial parent into the function via a parameter.
-void cc_omap_post_erase_fixup(
+static inline void cc_omap_post_erase_fixup(
   void *cntr,
   cc_omapnode_hdr_ty *node,
   cc_omapnode_hdr_ty *parent


### PR DESCRIPTION
First thank you for the excellent library and article with detailed benchmarks. When using this header with an `extern struct` defined which had a `map` field. I was getting the following linker issue

```
[build] duplicate symbol '_cc_omap_post_erase_fixup' in:
[build]     /VSCode/cc-cmake-issue/cmake-build-debug/CMakeFiles/test_cc_cmake_issue.dir/tests/test_cc_cmake_issue.c.o
[build]     libcc_cmake_issue.a[2](main.c.o)
[build] ld: 1 duplicate symbols
```

Changing the method signature to include `static inline` which matches the other function definitions resolved the issue. 