### PR TITLE
Better syntax highlighting in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,7 +818,11 @@ Full API documentation is available [here](api_reference.md).
 
 ### How does it work?
 
-**CC** associates type information with a container by declaring it as a pointer in the form of `element_type (*(*)[ container_type_id ])( key_type * )`. The pointer points to the container's metadata and contents. API macros use `sizeof`, `typeof`, and `_Generic` tricks to deduce the container, element, and key types from this pointer at compile time, selecting the relevant function and passing the type information, along with the pointer, into it.
+**CC** associates type information with a container by declaring it as a pointer in the form of 
+```C
+element_type (*(*)[ container_type_id ])( key_type * )
+```
+The pointer points to the container's metadata and contents. API macros use `sizeof`, `typeof`, and `_Generic` tricks to deduce the container, element, and key types from this pointer at compile time, selecting the relevant function and passing the type information, along with the pointer, into it.
 
 Destructor, comparison, and hash functions are also deduced via a novel technique for user-extendible `_Generic` macros.
 


### PR DESCRIPTION
Super minor and trivial change here. I noticed the way the type description in the readme was soft wrapping made it super difficult for me to read what was going on with the type.

### Before
<img width="924" alt="Screenshot 2025-04-16 at 10 02 30 PM" src="https://github.com/user-attachments/assets/feb2c5e0-1fa6-4cfb-99fd-c5fca73de22d" />

### After
<img width="1116" alt="Screenshot 2025-04-16 at 10 03 55 PM" src="https://github.com/user-attachments/assets/014e8885-7c35-430d-b939-bf135b8c136b" />